### PR TITLE
enabling git bash compatibility

### DIFF
--- a/cloudmesh/burn/command/burn.py
+++ b/cloudmesh/burn/command/burn.py
@@ -556,8 +556,7 @@ class BurnCommand(PluginCommand):
                                          'config')
                         else:
                             Console.ok(f"Using SSID: {ssid}")
-                    print(wifipasswd)
-                    if not wifipasswd:
+                    if not wifipasswd and not ssid == "":
                         if os_is_windows:
                             os.system("stty -echo")
                             wifipasswd = input(f"Using --SSID={ssid}, please "

--- a/cloudmesh/burn/command/burn.py
+++ b/cloudmesh/burn/command/burn.py
@@ -557,7 +557,7 @@ class BurnCommand(PluginCommand):
                         else:
                             Console.ok(f"Using SSID: {ssid}")
                     if not wifipasswd and not ssid == "":
-                        if os_is_windows:
+                        if os_is_windows():
                             os.system("stty -echo")
                             wifipasswd = input(f"Using --SSID={ssid}, please "
                                              f"enter wifi password:")

--- a/cloudmesh/burn/command/burn.py
+++ b/cloudmesh/burn/command/burn.py
@@ -525,13 +525,16 @@ class BurnCommand(PluginCommand):
                     locale = locale.strip()
 
                     arguments.tag = Parameter.expand(arguments.tag)
-                    if len(arguments.tag) == 1:
-                        tag = arguments.tag[0]
-                        arguments.tag = [tag for i in range(1 + len(workers))]
-                    elif len(arguments.tag) == 2:
-                        worker_image = arguments.tag[1]
-                        manager_image = arguments.tag[0]
-                        arguments.tag = [manager_image] + [worker_image for i in range(len(workers))]
+                    if arguments.tag:
+                        if len(arguments.tag) == 1:
+                            tag = arguments.tag[0]
+                            arguments.tag = [tag for i in range(1 + len(workers))]
+                        elif len(arguments.tag) == 2:
+                            worker_image = arguments.tag[1]
+                            manager_image = arguments.tag[0]
+                            arguments.tag = [manager_image] + [worker_image for i in range(len(workers))]
+                    else:
+                        arguments.TAG = "latest"
 
                     _build_default_inventory(filename=inventory,
                                              manager=manager,
@@ -553,9 +556,17 @@ class BurnCommand(PluginCommand):
                                          'config')
                         else:
                             Console.ok(f"Using SSID: {ssid}")
-                    if not wifipasswd and not ssid == "":
-                        wifipasswd = getpass(f"Using --SSID={ssid}, please "
+                    print(wifipasswd)
+                    if not wifipasswd:
+                        if os_is_windows:
+                            os.system("stty -echo")
+                            wifipasswd = input(f"Using --SSID={ssid}, please "
                                              f"enter wifi password:")
+                            os.system("stty echo")
+                            print("")
+                        else:
+                            wifipasswd = getpass(f"Using --SSID={ssid}, please "
+                                                f"enter wifi password:")
 
             execute("burn raspberry", burner.multi_burn(
                 names=arguments.NAMES,


### PR DESCRIPTION
when there is no wifi password provided, then burn hangs (when run on windows 10 git bash).
tested with `cms burn raspberry "red,red0[1-4]" --password=cludmesh4me --disk=1 --new`

this is because git bash does not support getpass
proof: 
https://stackoverflow.com/a/58277159

thus we implement a fix: 
```python
if not wifipasswd and not ssid == "":
                        if os_is_windows():
                            os.system("stty -echo")
                            wifipasswd = input(f"Using --SSID={ssid}, please "
                                             f"enter wifi password:")
                            os.system("stty echo")
                            print("")
                        else:
                            wifipasswd = getpass(f"Using --SSID={ssid}, please "
                                                f"enter wifi password:")
```

this still accomplishes purpose of hiding password, which is the very same purpose that getpass() is for.

we also check to see if arguments.tag is NoneType. if it is not provided (then it is NoneType) then tag is set as latest. i have made the proper changes in this pull request. 